### PR TITLE
fix: add missing feedparser dependency

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -29,6 +29,7 @@ httpx>=0.27.0
 
 # Web Scraping
 beautifulsoup4>=4.12.0
+feedparser>=6.0.10
 
 # FSRS Algorithm
 fsrs>=3.0.0
@@ -37,10 +38,8 @@ fsrs>=3.0.0
 langchain>=0.1.0
 langchain-text-splitters>=0.0.1
 langchain-openai>=0.0.5
-langchain-openai>=0.0.5
 openai>=1.10.0
 google-genai>=0.3.0
-instructor>=1.0.0
 instructor>=1.0.0
 
 # Notion SDK


### PR DESCRIPTION
- Add feedparser>=6.0.10 to backend/requirements.txt
- Remove duplicate langchain-openai and instructor entries