### PR TITLE
fix: handle stuck pending sources and ensure correct status transitions

### DIFF
--- a/backend/app/services/runner_service.py
+++ b/backend/app/services/runner_service.py
@@ -287,6 +287,9 @@ class RunnerService:
         # Log start of processing (Sync Started)
         process_start_time = time.time()
         await self._log_event(source.id, "sync_started", "running", message="Starting source processing")
+        
+        # Update status to PROCESSING
+        source.status = "PROCESSING"
         await self.db.commit()
 
         # 2. Extract Content (Text or Base64)


### PR DESCRIPTION
- Updated RunnerService to set PROCESSING status at start
- Updated background task error handler to set FAILED status
- Updated admin API to reset stuck PENDING sources (> 5 mins old)