### PR TITLE
fix: re-link source material when re-adding deleted paper

### DIFF
--- a/backend/app/services/runner_service.py
+++ b/backend/app/services/runner_service.py
@@ -350,9 +350,8 @@ class RunnerService:
                 logger.info(f"Found existing material used by another source, re-linking to source {source.id}")
                 source_material = existing_material
                 if source_material.source_id != source.id:
-                     # This might be tricky if one material is shared by multiple sources, 
-                     # but for now 1:1 or 1:N ownership transfer
-                     pass 
+                     source_material.source_id = source.id
+                     await self.db.flush()
             else:
                  source_material = SourceMaterial(
                     user_id=source.user_id,


### PR DESCRIPTION
When a paper source is deleted and re-added, the old SourceMaterial (with source_id=NULL) was found but not re-linked to the new Source. This caused study/papers endpoint to skip these cards since source was None. Now properly update source_material.source_id to the new source when re-using existing material.