### PR TITLE
fix(editor): fix infinite save loop and add proper db commit

### DIFF
--- a/backend/app/api/editor.py
+++ b/backend/app/api/editor.py
@@ -181,9 +181,10 @@ async def save_editor_content(
     from app.services.tiptap_converter import sync_tiptap_to_cards
     try:
         await sync_tiptap_to_cards(db, source_id, current_user.id, body.content)
-        await db.flush() # Ensure any newly created/archived cards are flushed
+        await db.commit() # Commit all changes including editor content and synced cards
     except Exception as e:
         logger.error(f"Failed to sync tiptap to cards for source {source_id}: {e}")
+        await db.rollback() # Rollback on error
 
     source_url = (source.connection_config or {}).get("url") if source.connection_config else None
 

--- a/backend/app/services/tiptap_converter.py
+++ b/backend/app/services/tiptap_converter.py
@@ -470,9 +470,9 @@ async def sync_tiptap_to_cards(db: AsyncSession, source_id: UUID, user_id: UUID,
     if len(sections) < len(existing_cards):
         for idx in range(len(sections), len(existing_cards)):
             card_to_archive = existing_cards[idx]
-            card_to_archive.status = CardStatus.ARCHIVED
-            
-    await db.commit()
+            if card_to_archive.status != CardStatus.ARCHIVED:
+                card_to_archive.status = CardStatus.ARCHIVED
+                db.add(card_to_archive)
 
 def json_to_markdown(nodes: list) -> str:
     """Basic helper to turn Tiptap nodes back into a readable markdown string for NoteCards."""

--- a/web/src/components/editor/TiptapEditor.tsx
+++ b/web/src/components/editor/TiptapEditor.tsx
@@ -135,9 +135,10 @@ export function TiptapEditor({ content, onUpdate, sourceId, editable = true }: T
     // Update content when prop changes (initial load)
     useEffect(() => {
         if (editor && content && !editor.isDestroyed) {
-            const currentJSON = JSON.stringify(editor.getJSON())
-            const newJSON = JSON.stringify(content)
-            if (currentJSON !== newJSON) {
+            // Only set content if the editor is completely empty (initial load)
+            // or if we're explicitly forcing a reset.
+            // Continuously calling setContent breaks the cursor position and causes infinite update loops.
+            if (editor.isEmpty) {
                 editor.commands.setContent(content as any)
             }
         }


### PR DESCRIPTION
- Fix useEffect in TiptapEditor causing infinite save/update cycle
- Move db.commit from tiptap_converter service to editor API endpoint
- Add rollback on sync failure
Signed-off-by: Shuai Wang <wangshuai212@huawei.com>