### PR TITLE
style: fix shared page layout and remove sidebar

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -452,15 +452,6 @@ body {
 }
 
 .shared-content-wrapper {
-  background: hsl(var(--card));
-  border: 1px solid hsl(var(--border));
-  border-radius: 0.75rem;
-  padding: 2rem;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.02);
-}
-
-@media (max-width: 768px) {
-  .shared-content-wrapper {
-    padding: 1rem;
-  }
+  max-width: 800px;
+  margin: 0 auto;
 }

--- a/web/src/components/layout/MainLayout.tsx
+++ b/web/src/components/layout/MainLayout.tsx
@@ -10,18 +10,19 @@ export function MainLayout({ children }: { children: React.ReactNode }) {
     const router = useRouter();
     const { user, isLoading, isAuthenticated } = useAuth();
 
-    const isPublic = pathname === "/login" || pathname === "/register" || pathname.startsWith("/auth");
+    const isAuthPage = pathname === "/login" || pathname === "/register" || pathname.startsWith("/auth");
+    const isPublic = isAuthPage || pathname.startsWith("/shared");
     const isFullScreen = pathname.startsWith("/gulp");
 
     useEffect(() => {
         if (!isLoading) {
             if (!isAuthenticated && !isPublic) {
                 router.push("/login");
-            } else if (isAuthenticated && isPublic) {
+            } else if (isAuthenticated && isAuthPage) {
                 router.push("/");
             }
         }
-    }, [isLoading, isAuthenticated, isPublic, router]);
+    }, [isLoading, isAuthenticated, isPublic, isAuthPage, router]);
 
     if (isLoading) {
         return (


### PR DESCRIPTION
- Add `/shared` to public routes in `MainLayout` so the sidebar is hidden and no auth is required

- Allow authenticated users to view shared pages without being redirected

- Remove duplicate border and background from `shared-content-wrapper` in CSS for a cleaner view